### PR TITLE
feat(config): session 30min idle timeout + context 5x expansion [WS2.4-04, WS2.4-05]

### DIFF
--- a/config/openclaw.prod.json5
+++ b/config/openclaw.prod.json5
@@ -44,11 +44,27 @@
     },
   },
 
+  // Session configuration
+  session: {
+    reset: {
+      // Idle timeout: reset session after 30 minutes of inactivity
+      // LINE OA users benefit from persistent context during active conversations
+      // while reclaiming resources for idle sessions
+      idleMinutes: 30,
+    },
+  },
+
   // Agent configuration
   agents: {
     defaults: {
       // Workspace directory
       workspace: "/data/openclaw/workspace",
+
+      // Context window: 5x expansion for sustained multi-turn conversations
+      // Defaults: bootstrapMaxChars=20K, bootstrapTotalMaxChars=150K, contextTokens=200K
+      bootstrapMaxChars: 100000,        // 5x per-file context (was 20,000)
+      bootstrapTotalMaxChars: 750000,   // 5x total bootstrap (was 150,000)
+      contextTokens: 1000000,           // 5x token window (was 200,000),
 
       // Model configuration (fallback chain with free tier safety net)
       model: {

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -98,14 +98,22 @@ docker exec "$CONTAINER_NAME" openclaw config set tools.exec.ask on-miss 2>/dev/
 docker exec "$CONTAINER_NAME" openclaw config set tools.exec.safeBins '["jq","cut","uniq","head","tail","tr","wc","date","uptime","whoami","hostname","ps","tree","curl","wget"]' 2>/dev/null || true
 echo "  exec config applied ✔"
 
-echo "[2c/4] Post-deploy: Apply embeddings config"
+echo "[2c/4] Post-deploy: Apply session + context config"
+# WS-2.4: Session idle timeout (30 min) and 5x context expansion
+docker exec "$CONTAINER_NAME" openclaw config set session.reset.idleMinutes 30 2>/dev/null || true
+docker exec "$CONTAINER_NAME" openclaw config set agents.defaults.bootstrapMaxChars 100000 2>/dev/null || true
+docker exec "$CONTAINER_NAME" openclaw config set agents.defaults.bootstrapTotalMaxChars 750000 2>/dev/null || true
+docker exec "$CONTAINER_NAME" openclaw config set agents.defaults.contextTokens 1000000 2>/dev/null || true
+echo "  session + context config applied ✔"
+
+echo "[2d/4] Post-deploy: Apply embeddings config"
 # R3 fix: Enable memory search via OpenAI embeddings (requires OPENAI_API_KEY in container env)
 docker exec "$CONTAINER_NAME" openclaw config set agents.defaults.memorySearch.provider openai 2>/dev/null || true
 docker exec "$CONTAINER_NAME" openclaw config set agents.defaults.memorySearch.sources '["memory"]' 2>/dev/null || true
 docker exec "$CONTAINER_NAME" openclaw config set agents.defaults.memorySearch.fallback none 2>/dev/null || true
 echo "  embeddings config applied ✔"
 
-echo "[2d/4] Post-deploy: Apply Nginx config (native LINE handler)"
+echo "[2e/4] Post-deploy: Apply Nginx config (native LINE handler)"
 # R3 fix: Route /line/ to native handler (port 18789) instead of Flask bridge (5100)
 # The updated nginx config is committed in docker/nginx/openclaw.conf
 if [ -f "$APP_DIR/docker/nginx/openclaw.conf" ]; then
@@ -122,7 +130,7 @@ else
   echo "  WARNING: Nginx config not found at $APP_DIR/docker/nginx/openclaw.conf"
 fi
 
-echo "[2e/4] Post-deploy: Update Flask bridge timeout"
+echo "[2f/4] Post-deploy: Update Flask bridge timeout"
 # Increase gunicorn timeout from 60s to 300s for the fallback Flask bridge
 FLASK_SERVICE="/etc/systemd/system/line-bridge.service"
 if [ -f "$FLASK_SERVICE" ]; then


### PR DESCRIPTION
## Changes
- Add `session.reset.idleMinutes: 30` to `openclaw.prod.json5` (WS2.4-05)
- Add 5x context expansion to `openclaw.prod.json5` (WS2.4-04):
  - `bootstrapMaxChars: 100000` (was 20K default)
  - `bootstrapTotalMaxChars: 750000` (was 150K default)
  - `contextTokens: 1000000` (was 200K default)
- Add deploy.sh step [2c/4] to apply session + context config on every deploy

## Testing
- Config keys applied via `openclaw config set` on container restart
- Regression test will verify values in WS2.4 regression suite