### PR TITLE
feat(ws24): add format_response.py utility + unit tests [WS2.4-02, WS2.4-03]

### DIFF
--- a/docker/scripts/format_response.py
+++ b/docker/scripts/format_response.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+format_response.py — OpenClaw Gateway Response Formatter
+
+Extracts human-readable text from OpenClaw gateway JSON responses.
+Used by the Flask bridge logging pipeline and regression tests.
+
+Output format:  {text} [{sessionId-8}]
+Example:        สวัสดีครับ [abc12345]
+
+Usage:
+    echo '{"payloads":[{"text":"hello"}],"meta":{"agentMeta":{"sessionId":"line-abc12345"}}}' | python3 format_response.py
+    python3 format_response.py response.json
+"""
+
+import json
+import sys
+
+
+def format_response(raw: str) -> str:
+    """
+    Parse an OpenClaw gateway JSON response and return a compact log line.
+
+    Args:
+        raw: JSON string from the gateway response body.
+
+    Returns:
+        Formatted string: "{text} [{sessionId-tail-8}]"
+
+    Raises:
+        ValueError: If JSON is malformed or required fields are missing.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Malformed JSON: {e}") from e
+
+    # Extract text from payloads
+    payloads = data.get("payloads")
+    if not payloads or not isinstance(payloads, list):
+        raise ValueError("Missing or empty 'payloads' array")
+
+    text = payloads[0].get("text")
+    if text is None:
+        raise ValueError("Missing 'text' in payloads[0]")
+
+    # Extract sessionId (navigate nested meta structure)
+    session_id = ""
+    meta = data.get("meta", {})
+    agent_meta = meta.get("agentMeta", {})
+    session_id = agent_meta.get("sessionId", "")
+
+    # Also check top-level sessionId as fallback
+    if not session_id:
+        session_id = data.get("sessionId", "")
+
+    # Format: take last 8 chars of sessionId
+    session_tail = session_id[-8:] if session_id else "no-session"
+
+    # Truncate text for log output (max 200 chars for log line)
+    display_text = text[:200] + "..." if len(text) > 200 else text
+
+    return f"{display_text} [{session_tail}]"
+
+
+def format_response_full(raw: str) -> dict:
+    """
+    Parse and return structured data from gateway response.
+
+    Returns:
+        dict with keys: text, sessionId, sessionTail, payloadCount
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Malformed JSON: {e}") from e
+
+    payloads = data.get("payloads", [])
+    if not payloads or not isinstance(payloads, list):
+        raise ValueError("Missing or empty 'payloads' array")
+
+    text = payloads[0].get("text", "")
+    meta = data.get("meta", {})
+    agent_meta = meta.get("agentMeta", {})
+    session_id = agent_meta.get("sessionId", data.get("sessionId", ""))
+
+    return {
+        "text": text,
+        "sessionId": session_id,
+        "sessionTail": session_id[-8:] if session_id else "",
+        "payloadCount": len(payloads),
+    }
+
+
+if __name__ == "__main__":
+    # Read from file argument or stdin
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], "r", encoding="utf-8") as f:
+            raw_input = f.read()
+    else:
+        raw_input = sys.stdin.read()
+
+    if not raw_input.strip():
+        print("ERROR: Empty input", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = format_response(raw_input)
+        print(result)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_format_response.py
+++ b/tests/test_format_response.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Tests for format_response.py — OpenClaw Gateway Response Formatter
+
+Run:  python3 -m pytest tests/test_format_response.py -v
+  or: python3 tests/test_format_response.py
+"""
+
+import json
+import os
+import sys
+import unittest
+
+# Add parent dir to path so we can import from docker/scripts
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "docker", "scripts"))
+
+from format_response import format_response, format_response_full
+
+
+class TestFormatResponse(unittest.TestCase):
+    """Test format_response() function."""
+
+    def test_happy_path(self):
+        """Basic response with text and sessionId."""
+        raw = json.dumps({
+            "payloads": [{"text": "Hello world"}],
+            "meta": {"agentMeta": {"sessionId": "line-U1234567890abcdef"}}
+        })
+        result = format_response(raw)
+        self.assertEqual(result, "Hello world [890abcdef]")
+
+    def test_thai_text(self):
+        """Thai (non-ASCII) text in response."""
+        raw = json.dumps({
+            "payloads": [{"text": "สวัสดีครับ ยินดีต้อนรับ"}],
+            "meta": {"agentMeta": {"sessionId": "line-abc12345678"}}
+        })
+        result = format_response(raw)
+        self.assertIn("สวัสดีครับ", result)
+        self.assertIn("[12345678]", result)
+
+    def test_short_session_id(self):
+        """SessionId shorter than 8 chars."""
+        raw = json.dumps({
+            "payloads": [{"text": "test"}],
+            "meta": {"agentMeta": {"sessionId": "abc"}}
+        })
+        result = format_response(raw)
+        self.assertEqual(result, "test [abc]")
+
+    def test_empty_session_id(self):
+        """Missing sessionId falls back to 'no-session'."""
+        raw = json.dumps({
+            "payloads": [{"text": "orphan response"}],
+            "meta": {"agentMeta": {}}
+        })
+        result = format_response(raw)
+        self.assertEqual(result, "orphan response [no-session]")
+
+    def test_no_meta_at_all(self):
+        """No meta field at all."""
+        raw = json.dumps({
+            "payloads": [{"text": "bare response"}]
+        })
+        result = format_response(raw)
+        self.assertEqual(result, "bare response [no-session]")
+
+    def test_top_level_session_id_fallback(self):
+        """SessionId at top level (not nested in meta)."""
+        raw = json.dumps({
+            "payloads": [{"text": "fallback test"}],
+            "sessionId": "direct-session-xyz"
+        })
+        result = format_response(raw)
+        self.assertIn("[sion-xyz]", result)
+
+    def test_long_text_truncated(self):
+        """Text longer than 200 chars is truncated."""
+        long_text = "x" * 250
+        raw = json.dumps({
+            "payloads": [{"text": long_text}],
+            "meta": {"agentMeta": {"sessionId": "line-trunctest"}}
+        })
+        result = format_response(raw)
+        self.assertTrue(result.startswith("x" * 200 + "..."))
+        self.assertIn("[runctest]", result)
+
+    def test_multi_payload_uses_first(self):
+        """Multiple payloads: only first text is used."""
+        raw = json.dumps({
+            "payloads": [
+                {"text": "first payload"},
+                {"text": "second payload"},
+                {"text": "third payload"}
+            ],
+            "meta": {"agentMeta": {"sessionId": "line-multi123"}}
+        })
+        result = format_response(raw)
+        self.assertIn("first payload", result)
+        self.assertNotIn("second", result)
+
+    def test_malformed_json(self):
+        """Invalid JSON raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            format_response("{not valid json")
+        self.assertIn("Malformed JSON", str(ctx.exception))
+
+    def test_missing_payloads(self):
+        """No payloads field raises ValueError."""
+        raw = json.dumps({"meta": {"agentMeta": {"sessionId": "test"}}})
+        with self.assertRaises(ValueError) as ctx:
+            format_response(raw)
+        self.assertIn("payloads", str(ctx.exception))
+
+    def test_empty_payloads_array(self):
+        """Empty payloads array raises ValueError."""
+        raw = json.dumps({"payloads": []})
+        with self.assertRaises(ValueError) as ctx:
+            format_response(raw)
+        self.assertIn("payloads", str(ctx.exception))
+
+    def test_missing_text_field(self):
+        """Payload without text field raises ValueError."""
+        raw = json.dumps({"payloads": [{"type": "image"}]})
+        with self.assertRaises(ValueError) as ctx:
+            format_response(raw)
+        self.assertIn("text", str(ctx.exception))
+
+
+class TestFormatResponseFull(unittest.TestCase):
+    """Test format_response_full() function."""
+
+    def test_full_output_structure(self):
+        """Returns dict with expected keys."""
+        raw = json.dumps({
+            "payloads": [{"text": "hello"}, {"text": "world"}],
+            "meta": {"agentMeta": {"sessionId": "line-full123456"}}
+        })
+        result = format_response_full(raw)
+        self.assertEqual(result["text"], "hello")
+        self.assertEqual(result["sessionId"], "line-full123456")
+        self.assertEqual(result["sessionTail"], "l123456")
+        self.assertEqual(result["payloadCount"], 2)
+
+    def test_full_no_session(self):
+        """Missing sessionId returns empty strings."""
+        raw = json.dumps({"payloads": [{"text": "test"}]})
+        result = format_response_full(raw)
+        self.assertEqual(result["sessionId"], "")
+        self.assertEqual(result["sessionTail"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes
- `docker/scripts/format_response.py`: Extract text + sessionId tail from gateway JSON
- `tests/test_format_response.py`: 14 unit tests (happy path, Thai text, truncation, multi-payload, errors)
- Output format: `{text} [{sessionId-8}]`

## Functions
- `format_response(raw)`: Returns compact log line
- `format_response_full(raw)`: Returns structured dict (text, sessionId, payloadCount)

## Testing
- 14 unit tests covering: happy path, Thai/non-ASCII, short/missing sessionId, truncation, multi-payload, malformed JSON, missing fields