### PR TITLE
feat(discord): enable Discord channel for NongKung bot

### DIFF
--- a/config/openclaw.prod.json5
+++ b/config/openclaw.prod.json5
@@ -1,4 +1,4 @@
-{
+﻿{
   "models": {
     "providers": {
       "openrouter": {
@@ -30,5 +30,18 @@
   "fallbacks": [
     "anthropic/claude-opus-4-6",
     "anthropic/claude-sonnet-4-6"
-  ]
+  ],
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "groupPolicy": "allowlist",
+      "guilds": {
+        "1484074676245499936": {
+          "requireMention": false,
+          "users": ["482725865986326528"]
+        }
+      }
+    }
+  }
 }

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -71,6 +71,7 @@ services:
       # Channel API credentials (LINE, Discord, Telegram, etc.)
       LINE_CHANNEL_ACCESS_TOKEN: ${LINE_CHANNEL_ACCESS_TOKEN:-}
       LINE_CHANNEL_SECRET: ${LINE_CHANNEL_SECRET:-}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
 
       # Docker Hub (for image pulls)
       DOCKER_USERNAME: ${DOCKER_USERNAME:-}


### PR DESCRIPTION
﻿## Summary

Enable Discord channel for the NongKung bot.

## Changes

- docker/docker-compose.prod.yml: Added DISCORD_BOT_TOKEN env var under Channel API credentials section.
- config/openclaw.prod.json5: Added discord block under channels with guild allowlist config.

## Discord Config

Server ID: 1484074676245499936
User ID: 482725865986326528
dmPolicy: pairing, groupPolicy: allowlist, requireMention: false

## Notes

- DISCORD_BOT_TOKEN secret is already set in GitHub Actions secrets.
- .env.example already documents DISCORD_BOT_TOKEN - no change required.

Closes #27
