### PR TITLE
fix(config): enable tools.media.image for Discord image processing (#506)

### DIFF
--- a/config/openclaw.prod.json5
+++ b/config/openclaw.prod.json5
@@ -429,6 +429,21 @@
         },
       },
     },
+
+    // Image/media processing configuration
+    // Enables Discord image attachments to be processed by the agent
+    // Refs: Piboonsak/Openclaw#506 (bug: NongKung ไม่เห็นรูปภาพที่แนบใน Discord message)
+    media: {
+      image: {
+        enabled: true,
+        maxBytes: 10485760, // 10 MB per image
+        timeoutSeconds: 30,
+        attachments: {
+          mode: "all",       // "all" = process all attached images
+          maxAttachments: 5, // max images per message
+        },
+      },
+    },
   },
 
   // Sandbox configuration (defense in depth)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes Piboonsak/Openclaw#506 (bug: NongKung ไม่เห็นรูปภาพที่แนบใน Discord message)

## 📝 Summary

### Root Cause
Production config (`config/openclaw.prod.json5`) was missing the `tools.media.image` section entirely. Without it, OpenClaw defaults to disabled image processing — all Discord image attachments were silently ignored.

### Fix
Added `tools.media` section inside `tools` block:

```json5
media: {
  image: {
    enabled: true,
    maxBytes: 10485760, // 10 MB per image
    timeoutSeconds: 30,
    attachments: {
      mode: "all",
      maxAttachments: 5,
    },
  },
},
```

### KI Gate
- **No KI match → proposing new fix**
- KI-073 risk checked: `tools.media` is a new top-level field under `tools` (not under `agents.defaults`). The deploy workflow's selective merge step syncs `tools.exec.*` but may not sync `tools.media.*`. This needs to be verified in the deploy workflow after merge.

## 🏷️ Change Type

- [x] 🐛 Bug Fix → **Procedure B** (`docs/cicd/03-pre-fix-protocol.md` → `04` → `05` → `06`)

## 📋 CI/CD Compliance

- [x] KI gate declared: No KI match → proposing new fix
- [x] Source code reviewed (runtime config, tools section)
- [x] Change is limited to intended fields only
- [x] No secrets/tokens in code
- [x] Conventional Commit format
- [x] References issue number (#506)

## ⚠️ Risk Assessment

- **Risk:** LOW — adding new config section, not modifying existing
- **Deploy path:** Hotfix deploy via `deploy-hotfix-openclaw-github-private-secrets.yml` (no build needed)
- **Rollback:** Remove `media` section, trigger hotfix redeploy

---

> 📖 CI/CD Master Index: `docs/cicd/README.md`
> ⚠️ Note: After merge, verify `tools.media` is included in deploy workflow sync whitelist (KI-073)